### PR TITLE
Add tests for working days calculation

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -37,6 +37,10 @@ function calculateWorkingDays(year, month) {
     return count;
 }
 
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { getHolidays, calculateWorkingDays };
+} else {
+
 // ----------------------------
 // Debounce Helper Function
 // ----------------------------
@@ -925,3 +929,5 @@ window.createFakeMarkData = function () {
         });
     }
 };
+
+}

--- a/tests/calculateWorkingDays.test.js
+++ b/tests/calculateWorkingDays.test.js
@@ -1,0 +1,16 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { calculateWorkingDays, getHolidays } = require('../js/script.js');
+
+test('calculateWorkingDays excludes weekends', () => {
+  const workingDays = calculateWorkingDays(2021, 1); // February 2021
+  assert.strictEqual(workingDays, 20);
+});
+
+test('calculateWorkingDays excludes holidays from getHolidays', () => {
+  const holidays = getHolidays(2021).filter(h => h.getMonth() === 2); // March holidays
+  assert.ok(holidays.some(h => h.getDate() === 3));
+  assert.ok(holidays.some(h => h.getDate() === 4));
+  const workingDays = calculateWorkingDays(2021, 2); // March 2021
+  assert.strictEqual(workingDays, 21); // 23 weekdays - 2 holidays
+});


### PR DESCRIPTION
## Summary
- expose `calculateWorkingDays` and `getHolidays` for tests
- add test verifying weekends and holidays are excluded

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68991adb203c8327b0dd79284f0b73cc