### PR TITLE
Handle Windows newlines in CSV import

### DIFF
--- a/js/ui/ui.js
+++ b/js/ui/ui.js
@@ -284,7 +284,7 @@ export class AttendanceUI {
     }
 
     importCSV(csvText) {
-        const lines = csvText.trim().split('\n');
+        const lines = csvText.trim().split(/\r?\n/);
         if (lines.length < 2) {
             alert("CSV file is empty or missing data.");
             return;


### PR DESCRIPTION
## Summary
- Adjust CSV import to split on both Unix and Windows line endings

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_689922514c888327bea820016901214d