### PR TITLE
Add working day and distance tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "attendance-tracker",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/tests/calculateDistance.test.js
+++ b/tests/calculateDistance.test.js
@@ -1,0 +1,16 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { calculateDistance } from '../js/helpers.js';
+
+test('calculateDistance returns 0 for identical locations', () => {
+  const loc = { latitude: 0, longitude: 0 };
+  assert.strictEqual(calculateDistance(loc, loc), 0);
+});
+
+test('calculateDistance approximates known distances', () => {
+  const loc1 = { latitude: 0, longitude: 0 };
+  const loc2 = { latitude: 0, longitude: 1 }; // ~111.2 km at equator
+  const distance = calculateDistance(loc1, loc2);
+  // allow small tolerance for floating point arithmetic
+  assert.ok(Math.abs(distance - 111194.9) < 100);
+});

--- a/tests/calculateWorkingDays.test.js
+++ b/tests/calculateWorkingDays.test.js
@@ -1,0 +1,34 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { calculateWorkingDays, getHolidays } from '../js/attendance/utils.js';
+
+// Verify weekends are excluded using February 2024 (leap year)
+test('calculateWorkingDays excludes weekends in February 2024', () => {
+  const workingDays = calculateWorkingDays(2024, 1); // February
+  assert.strictEqual(workingDays, 21);
+});
+
+// Verify holidays from getHolidays are excluded
+// Using March 2024 which contains a Carnival holiday on March 4th (Monday)
+test('calculateWorkingDays excludes holidays returned by getHolidays', () => {
+  const year = 2024;
+  const month = 2; // March
+  const workingDays = calculateWorkingDays(year, month);
+
+  // Count weekdays in March 2024
+  const date = new Date(year, month, 1);
+  let weekdayCount = 0;
+  while (date.getMonth() === month) {
+    const day = date.getDay();
+    if (day !== 0 && day !== 6) weekdayCount++;
+    date.setDate(date.getDate() + 1);
+  }
+
+  // Determine how many holidays fall on weekdays in March 2024
+  const holidays = getHolidays(year);
+  const holidaysOnWeekdays = holidays.filter((h) =>
+    h.getMonth() === month && h.getDay() !== 0 && h.getDay() !== 6
+  ).length;
+
+  assert.strictEqual(workingDays, weekdayCount - holidaysOnWeekdays);
+});


### PR DESCRIPTION
## Summary
- add Node test runner configuration
- verify working day calculations exclude weekends and holidays
- cover distance helper with basic accuracy checks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689926a431e88327b4a43010cc377059