### PR TITLE
fix: refresh stats after resetting options

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -684,6 +684,8 @@ class AttendanceUI {
             document.getElementById('attendanceGoalValue').textContent = "55%";
             this.attendanceGoalPercentage = 55;
             this.manager.requiredAttendance = Math.ceil(this.manager.workingDays * 0.55);
+            this.optionsManager.saveOptions();
+            this.updateAll();
         });
         document.getElementById('attendanceGoalSlider').addEventListener('input', (e) => {
             const goalPercentage = parseInt(e.target.value, 10);


### PR DESCRIPTION
## Summary
- ensure resetting options also saves defaults and refreshes progress statistics

## Testing
- `npm test` *(fails: ENOENT Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689919364e088327961af7957bb1be9c